### PR TITLE
Use ajax .fail

### DIFF
--- a/cchecker_web/static/js/app/index.js
+++ b/cchecker_web/static/js/app/index.js
@@ -182,7 +182,7 @@ _.extend(App.prototype, {
         self.pollResult(data.job_id);
       });
 
-      req.error(function(jqXHR, textStatus, error) {
+      req.fail(function(jqXHR, textStatus, error) {
         if(jqXHR.status == 413) {
           $('.drop-status').html('<div class="alert alert-danger">File is too large!</div>');
         } else if(jqXHR.status == 400) {


### PR DESCRIPTION
.fail method replaces the deprecated .error()