### PR TITLE
Css and feedback button image loading in production/non-debug mode

### DIFF
--- a/Assets.json
+++ b/Assets.json
@@ -77,14 +77,12 @@
       "cchecker_web/static/css/compiled/report.css":[
         "cchecker_web/static/lib/bootstrap/dist/css/bootstrap.min.css",
         "cchecker_web/static/lib/bootstrap-select/dist/css/bootstrap-select.min.css",
-        "cchecker_web/static/lib/font-awesome/css/font-awesome.css",
         "cchecker_web/static/css/result.css",
         "cchecker_web/static/css/main.css"
       ],
       "cchecker_web/static/css/compiled/index.css":[
         "cchecker_web/static/lib/bootstrap/dist/css/bootstrap.min.css",
         "cchecker_web/static/lib/bootstrap-select/dist/css/bootstrap-select.min.css",
-        "cchecker_web/static/lib/font-awesome/css/font-awesome.css",
         "cchecker_web/static/css/main.css",
         "cchecker_web/static/css/index.css",
         "cchecker_web/static/css/ioos_navbar.css",

--- a/cchecker_web/static/css/main.css
+++ b/cchecker_web/static/css/main.css
@@ -262,7 +262,7 @@ thead .ccorrection {
 
 #feedback{
 	border:0px solid #fff;
-	background:#660000 url('../img/feedback-tab-left.png') top left no-repeat;
+	background:#660000 url('/img/feedback-tab-left.png') top left no-repeat;
 	width:36px;
 	height:100px;
 	position:fixed;

--- a/cchecker_web/templates/base.html
+++ b/cchecker_web/templates/base.html
@@ -10,6 +10,7 @@
   <meta name="author" content="IOOS">
   <meta name="url-root" content="{{ url_root() }}">
   <link href='https://fonts.googleapis.com/css?family=Anonymous+Pro' rel='stylesheet' type='text/css'>
+  <link href='/lib/font-awesome/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
 <style>
 @font-face {
   font-family: 'KlinicSlabBold';


### PR DESCRIPTION
Moved font awesome out of the Assets.json file, not necessary to compile this into index.css since we can use the minified version. Having this added to Assets.json was causing issues with font awesome relative path not working in library. 

Also changed the path to the feedback button image to be absolute since the path will be different when using compiled or non-compiled/Debug/non-debug mode when using a relative path. 
