### PR TITLE
Use -j make option, consolidate yum install steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,28 +12,22 @@ RUN (curl -sL https://rpm.nodesource.com/setup_10.x | bash) && \
 # Install container dependencies:
 RUN yum -y install epel-release && \
     yum -y update && \
-    yum -y install make \
-    yum -y install git \
-    yum -y m4 \
-    yum -y zlib-devel \
-    yum -y install redis
+    yum -y install make git m4 zlib-devel redis
 
 RUN yum -y groupinstall "Development Tools"
 
 # Python 3.6 update:
 RUN yum update -y \
     && yum install -y python36 python36-libs python36-devel python36-pip \
-    && yum install -y which gcc \ 
-    && yum install -y udunits2-devel \
-    && yum install -y expat-devel \
-    && yum install -y openldap-devel 
+    which gcc udunits2-devel expat-devel openldap-devel httpd \
+    && yum clean all
 
 # UDUNITS
 RUN curl -O ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.25.tar.gz \
     && tar xzf udunits-2.2.25.tar.gz \
     && cd udunits-2.2.25 \
     && /bin/sh configure --prefix=/usr/local \
-    && make \
+    && make -j \
     && make install \
     && cd .. \
     && rm -rf udunits-2.2.25 \
@@ -44,7 +38,7 @@ RUN curl -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.19/
     && tar xzf hdf5-1.8.19.tar.gz \
     && cd hdf5-1.8.19 \
     && /bin/sh configure --prefix=/usr/local \
-    && make \
+    && make -j \
     && make install \
     && cd .. \
     && rm -rf hdf5-1.8.19 \
@@ -55,14 +49,12 @@ RUN curl -O ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.1.tar.gz \
     && tar xzf netcdf-4.4.1.1.tar.gz \
     && cd netcdf-4.4.1.1 \
     && /bin/sh configure --prefix=/usr/local \
-    && make \
+    && make -j \
     && make install \
     && cd .. \
     && rm -rf netcdf-4.4.1.1 \
     && rm -rf netcdf-4.4.1.1.tar.gz
 
-RUN yum -y install httpd
-RUN yum clean all
 RUN systemctl enable httpd.service
 
 # pipenv installation


### PR DESCRIPTION
Speed up build times by using the -j option for make. Consolidate
package install and clean-up steps using yum to further reduce
build size; by running the yum clean step separately, the metadata
was never actually removed.

Implements @benjwadams' guru feedback.