### PR TITLE
Remove function that alters the dimensions of .cdl

### DIFF
--- a/cchecker_web/upload.py
+++ b/cchecker_web/upload.py
@@ -105,39 +105,9 @@ def check_for_cdl(filename, filepath):
         nc_file = filename.replace('.cdl', '.nc')
         nc_path = os.path.join(os.path.dirname(filepath),
                                encode(nc_file))
-        filepath = update_cdl_dimensions(filepath)
         generate_dataset(nc_path, filepath)
         filepath = nc_path
     return filepath
-
-
-def update_cdl_dimensions(filepath):
-    '''
-    Rewrite the cdl file to make all dimensions size 1
-
-    :param str filepath: Absolute path to .cdl file
-    '''
-    transform = False
-    data = []
-    with open(filepath, 'r') as f:
-        lines = f.readlines()
-
-    for line in lines:
-        if 'variables:' in line:
-            transform = False
-        elif transform:
-            prefix = line.split('=')[0]
-            line = prefix + '= 1 ;\n'
-        elif 'dimensions:' in line:
-            # This is where we start transforming dimensions
-            transform = True
-        data.append(line)
-
-    # Re write the file
-    with open(filepath, 'w') as f:
-        f.write(''.join(data))
-    return filepath
-
 
 def encode(s):
     return base64.b64encode(s.encode('utf-8')).decode('ascii')

--- a/contrib/config/config.yml
+++ b/contrib/config/config.yml
@@ -1,8 +1,8 @@
 COMMON: &common
-  MAX_CONTENT_LENGTH: 16793600 # 16 MB
-  LOGGING: True
-  LOG_FILE_PATH: '/var/log/ccweb/'
-  LOG_FILE: 'cchecker_web.log'
+  MAX_CONTENT_LENGTH: 16793600
+  LOGGING: true
+  LOG_FILE_PATH: /var/log/ccweb/
+  LOG_FILE: cchecker_web.log
   HOST: localhost
   PORT: 3000
   DEBUG: True
@@ -10,14 +10,17 @@ COMMON: &common
   REDIS_HOST: redis
   REDIS_PORT: 6379
   REDIS_DB: 0
+  DEBUG: True
 
   CACHE:
     CACHE_TYPE: simple
-    
+
+  GOOGLE_ANALYTICS_ID:
+
 DEVELOPMENT: &development
-  <<: *common 
+  <<: *common
   DEBUG: True
 
 PRODUCTION: &production
   <<: *common
-  DEBUG: False
+  DEBUG: True

--- a/contrib/config/config.yml
+++ b/contrib/config/config.yml
@@ -1,11 +1,10 @@
 COMMON: &common
-  MAX_CONTENT_LENGTH: 16793600
-  LOGGING: true
+  MAX_CONTENT_LENGTH: 16793600 # 16 MB
+  LOGGING: True
   LOG_FILE_PATH: /var/log/ccweb/
   LOG_FILE: cchecker_web.log
   HOST: localhost
   PORT: 3000
-  DEBUG: True
   UPLOAD_FOLDER: /var/run/datasets
   REDIS_HOST: redis
   REDIS_PORT: 6379
@@ -23,4 +22,4 @@ DEVELOPMENT: &development
 
 PRODUCTION: &production
   <<: *common
-  DEBUG: True
+  DEBUG: False

--- a/contrib/docker/my_init.d/run.sh
+++ b/contrib/docker/my_init.d/run.sh
@@ -1,44 +1,4 @@
 #!/bin/bash
-set -ex
-
-: ${MAX_CONTENT_LENGTH:=16793600}
-: ${LOGGING:=true}
-: ${LOG_FILE_PATH:=/var/log/ccweb/}
-: ${LOG_FILE:=cchecker_web.log}
-: ${UPLOAD_FOLDER:=/var/run/datasets}
-: ${REDIS_HOST:=redis}
-: ${REDIS_PORT:=6379}
-: ${REDIS_DB:=0}
-: ${DEBUG:=false}
-
-cat << EOF > /usr/lib/ccweb/config.yml
-COMMON: &common
-  MAX_CONTENT_LENGTH: ${MAX_CONTENT_LENGTH}
-  LOGGING: ${LOGGING}
-  LOG_FILE_PATH: ${LOG_FILE_PATH}
-  LOG_FILE: ${LOG_FILE}
-  HOST: localhost
-  PORT: 3000
-  DEBUG: True
-  UPLOAD_FOLDER: /var/run/datasets
-  REDIS_HOST: redis
-  REDIS_PORT: 6379
-  REDIS_DB: 0
-  DEBUG: True
-
-  CACHE:
-    CACHE_TYPE: simple
-
-  GOOGLE_ANALYTICS_ID: ${GOOGLE_ANALYTICS_ID}
-
-DEVELOPMENT: &development
-  <<: *common
-  DEBUG: True
-
-PRODUCTION: &production
-  <<: *common
-  DEBUG: ${DEBUG}
-EOF
 
 set -e
 wait_for_redis(){

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     command: redis-server --appendonly yes
 
   compliance-checker:
-    image: test_ccweb:latest
+    image: ioos/compliance-checker-web:latest
     container_name: compliance-checker-web
     env_file: .env
     volumes:


### PR DESCRIPTION
Altering the dimensions of the user-supplied .cdl file causes some checks
to fail where they would otherwise pass and generates inconcistencies when
testing against a .cdl versus a .nc(4) file. Remove the function which
changes the dimensions to `1`.

The `my_init.d/run.sh` script generates a new config.yml each time it is
run, which is every time a new Docker image is built. A config.yml is already
included in the version control; changing this each time may lead to confuse
developers who choose to put certain options in to the config.yml and having
it change without them knowing.

Update the image the docker-compose.yml uses to "ioos/compliance-checker-web"
instead of the colloquial and unofficial "test_ccweb".