### PR TITLE
Simplify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM centos:7.6.1810
+FROM centos/python-38-centos7
 
-MAINTAINER RPS <devops@rpsgroup.com>
+LABEL maintainer="RPS <devops@rpsgroup.com>"
 
 USER root
 
@@ -12,60 +12,15 @@ RUN (curl -sL https://rpm.nodesource.com/setup_10.x | bash) && \
 # Install container dependencies:
 RUN yum -y install epel-release && \
     yum -y update && \
-    yum -y install make git m4 zlib-devel redis
+    yum -y install redis
 
 RUN yum -y groupinstall "Development Tools"
 
-# Python 3.6 update:
 RUN yum update -y \
-    && yum install -y python36 python36-libs python36-devel python36-pip \
-    which gcc udunits2-devel expat-devel openldap-devel httpd \
+    && yum install -y httpd \
     && yum clean all
 
-# UDUNITS
-RUN curl -O ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.25.tar.gz \
-    && tar xzf udunits-2.2.25.tar.gz \
-    && cd udunits-2.2.25 \
-    && /bin/sh configure --prefix=/usr/local \
-    && make -j \
-    && make install \
-    && cd .. \
-    && rm -rf udunits-2.2.25 \
-    && rm -rf udunits-2.2.25.tar.gz
-
-# HDF5
-RUN curl -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.19/src/hdf5-1.8.19.tar.gz \
-    && tar xzf hdf5-1.8.19.tar.gz \
-    && cd hdf5-1.8.19 \
-    && /bin/sh configure --prefix=/usr/local \
-    && make -j \
-    && make install \
-    && cd .. \
-    && rm -rf hdf5-1.8.19 \
-    && rm -rf hdf5-1.8.19.tar.gz
-
-# NETCDF4
-RUN curl -O ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.4.1.1.tar.gz \
-    && tar xzf netcdf-4.4.1.1.tar.gz \
-    && cd netcdf-4.4.1.1 \
-    && /bin/sh configure --prefix=/usr/local \
-    && make -j \
-    && make install \
-    && cd .. \
-    && rm -rf netcdf-4.4.1.1 \
-    && rm -rf netcdf-4.4.1.1.tar.gz
-
 RUN systemctl enable httpd.service
-
-# pipenv installation
-RUN pip3.6 install pipenv
-RUN ln -s /usr/bin/pip3.6 /bin/pip
-RUN rm /usr/bin/python
-# python must be pointing to python3.6
-RUN ln -s /usr/bin/python3.6 /usr/bin/python
-
-RUN pip install Cython --install-option="--no-cython-compile"
-RUN pip install numpy
 
 # Startup Shell script:
 COPY contrib/docker/my_init.d/run.sh /etc/run.sh
@@ -84,9 +39,12 @@ RUN chown -R ccweb:ccweb /usr/lib/ccweb /var/run/datasets /var/log/ccweb
 WORKDIR /usr/lib/ccweb
 
 # Install python dependencies
-RUN pip --version && pip install -r requirements.txt
+RUN python3.8 -m pip install --upgrade pip &&\
+    python3.8 -m pip --version &&\
+    pip install -r requirements.txt
 
 # Install local dependencies
+RUN chown -R ccweb ~/.config
 USER ccweb
 RUN yarn install && \
     grunt

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ LABEL maintainer="RPS <devops@rpsgroup.com>"
 USER root
 
 # Install nodejs/npm and friends:
-RUN (curl -sL https://rpm.nodesource.com/setup_10.x | bash) && \
-    yum -y install nodejs && \
+RUN (curl -sL https://rpm.nodesource.com/setup_14.x | bash) && \
     npm install -g grunt-cli yarn
 
 # Install container dependencies:

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /usr/lib/ccweb
 # Install python dependencies
 RUN python3.8 -m pip install --upgrade pip &&\
     python3.8 -m pip --version &&\
-    pip install -r requirements.txt
+    pip3.8 install -r requirements.txt
 
 # Install local dependencies
 RUN chown -R ccweb ~/.config

--- a/cchecker_web/flask_environments.py
+++ b/cchecker_web/flask_environments.py
@@ -76,7 +76,7 @@ class Environments(object):
 
     def from_yaml(self, path):
         with open(path) as f:
-            c = yaml.load(f)
+            c = yaml.safe_load(f)
 
         for name in self._possible_names():
             try:

--- a/contrib/docker/my_init.d/run.sh
+++ b/contrib/docker/my_init.d/run.sh
@@ -12,10 +12,9 @@ wait_for_redis(){
 
 wait_for_redis
 
-exec /usr/bin/python \
-         /usr/lib/ccweb/worker.py &
+exec python3.8 /usr/lib/ccweb/worker.py &
 
-exec /usr/local/bin/gunicorn \
+exec /opt/app-root/bin/gunicorn \
          --workers 2 \
          --bind 0.0.0.0:3000 \
          --chdir /usr/lib/ccweb \

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,8 @@ PyYAML>=3.11
 redis>=2.10.5
 rq>=0.6.0
 compliance-checker
-cython
 gunicorn
-netcdftime
 numpy
-cf_units==2.0.2
+cf-units
 cc-plugin-ncei
 cc-plugin-glider

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,5 @@ redis>=2.10.5
 rq>=0.6.0
 compliance-checker
 gunicorn
-numpy
-cf-units
 cc-plugin-ncei
 cc-plugin-glider

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ compliance-checker
 gunicorn
 cc-plugin-ncei
 cc-plugin-glider
+cc-plugin-ugrid

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,9 +1318,9 @@ underscore.string@~3.3.4:
     util-deprecate "^1.0.2"
 
 underscore@>=1.4.2, underscore@>=1.7.0, underscore@>=1.8.3:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.10.2.tgz#73d6aa3668f3188e4adb0f1943bd12cfd7efaaaf"
-  integrity sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
+  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 uri-path@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
@benjwadams after our debug session yesterday I decided to take a look into the Dockerfile and made a few modifications. In this PR:

- we rely more heavily on Python wheels
- update the centos image so we can use at least python 3.8
- simplify and update the requirements.txt
- fix the deprecated `MAINTAINER` syntax in Dockerfiles

We can probably simplify this further by reducing the layers and removing the yum installation of epel-release and redis. The former I'm not sure we need and the latter is duplicated from the docker composition later.

Bare in mind that I did not test the actual deployment, just the build!