### PR TITLE
Bump compliance-checker to 5.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ flask-caching>=1.10.1
 PyYAML>=6.0
 redis>=4.5.4
 rq>=1.13.0
-compliance-checker
+compliance-checker==5.3.0
 gunicorn>=20.1.0
 cc-plugin-ncei
 cc-plugin-glider


### PR DESCRIPTION
When we deploy this we only get the latest, but it would be nice to track that with PRs.

@benjwadams can you deploy this after we merge this PR? Also, maybe we should update the HTML to show the compliance-checker version too?