### PR TITLE
Upgrade to Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,6 @@ RUN dnf -y install openssl-devel bzip2-devel libffi-devel sqlite-devel \
     # Clean up source
     cd / && rm -rf /usr/src/Python-3.11.6*
 
-# Install udunits2 and set UDUNITS2_XML_PATH
-RUN dnf -y install udunits2-devel udunits2
-ENV UDUNITS2_XML_PATH=/usr/share/udunits/udunits2.xml
 
 # Startup Shell script
 COPY contrib/docker/my_init.d/run.sh /etc/run.sh

--- a/cchecker_web/processing.py
+++ b/cchecker_web/processing.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import unicode_literals
 from compliance_checker.runner import CheckSuite
 import six
 import base64

--- a/contrib/docker/my_init.d/run.sh
+++ b/contrib/docker/my_init.d/run.sh
@@ -12,9 +12,9 @@ wait_for_redis(){
 
 wait_for_redis
 
-exec python3.8 /usr/lib/ccweb/worker.py &
+python3 /usr/lib/ccweb/worker.py &
 
-exec /usr/local/bin/gunicorn \
+exec gunicorn \
          --workers 2 \
          --bind 0.0.0.0:3000 \
          --chdir /usr/lib/ccweb \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   redis:
-    image: redis:3.0.7-alpine
+    image: redis:7.0-alpine
     container_name: redis
     command: redis-server --appendonly yes
   compliance-checker:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,5 @@ gunicorn>=20.1.0
 cc-plugin-ncei
 cc-plugin-glider
 cc-plugin-ugrid>=1.1.0
-# we only need this for wheel based apps, anything installing from source or conda-forge is OK with older versions
-# see https://github.com/Unidata/netcdf4-python/issues/1151 for more context
 netcdf4>=1.6.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ compliance-checker==5.3.0
 gunicorn>=20.1.0
 cc-plugin-ncei
 cc-plugin-glider
-cc-plugin-ugrid
+cc-plugin-ugrid >=1.1.0
 # we only need this for wheel based apps, anything installing from source or conda-forge is OK with older versions
 # see https://github.com/Unidata/netcdf4-python/issues/1151 for more context
 netcdf4>=1.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ compliance-checker==5.3.0
 gunicorn>=20.1.0
 cc-plugin-ncei
 cc-plugin-glider
-cc-plugin-ugrid >=1.1.0
+cc-plugin-ugrid>=1.1.0
 # we only need this for wheel based apps, anything installing from source or conda-forge is OK with older versions
 # see https://github.com/Unidata/netcdf4-python/issues/1151 for more context
 netcdf4>=1.6.3

--- a/worker.py
+++ b/worker.py
@@ -3,7 +3,7 @@
 '''
 worker.py
 '''
-from rq import Worker, Queue, Connection
+from rq import Worker, Queue
 from app import redis_connection
 from compliance_checker.runner import CheckSuite
 
@@ -18,7 +18,8 @@ CheckSuite.load_all_available_checkers()
 
 logging.basicConfig(level=logging.DEBUG)
 
+# Build Queue objects bound to our Redis connection
+queues = [Queue(name, connection=redis_connection) for name in listen]
 
-with Connection(redis_connection):
-    worker = Worker(map(Queue, listen))
-    worker.work()
+worker = Worker(queues, connection=redis_connection)
+worker.work()


### PR DESCRIPTION
https://github.com/ioos/compliance-checker-web/pull/136

- Update to Python 3.11 and related scripts/files
- Shuffled around Dockerfile for optimized rebuilds
- Tested:
  -  Dataset upload
  - Remote OpenDAP URL
  - Report Download

I tried to upgrade to 3.12/3.13 too, but it wasn't plug and play from 3.11. Ran into issues with `cc-plugin-ugrid`
```
AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
```